### PR TITLE
Update AndroidUSBInterface.java

### DIFF
--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInterface.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInterface.java
@@ -48,8 +48,12 @@ import com.digi.xbee.api.exceptions.PermissionDeniedException;
 public class AndroidUSBInterface implements IConnectionInterface {
 
 	// Constants.
-	private static final int VID = 0x0403;
-	private static final int[] FTDI_PIDS = {
+	private static final int[] VID = { 
+		        0x0403, // FTDI  
+		        0x04E2, // EXAR
+	};
+	private static final int[] UART_PIDS = {
+		        0x1410, // XR21V1410
 			0x6001, // FT232 and FT245
 			//0x6010, // FT2232
 			0x6011, // FT4232
@@ -410,8 +414,8 @@ public class AndroidUSBInterface implements IConnectionInterface {
 		UsbDevice usbDevice = null;
 		HashMap<String, UsbDevice> deviceList = usbManager.getDeviceList();
 		for (UsbDevice device:deviceList.values()) {
-			if (device.getVendorId() == VID) {
-				for (int pid:FTDI_PIDS) {
+			if (device.getVendorId() == VID[0] || device.getVendorId() == VID[1]) {
+				for (int pid:UART_PIDS) {
 					if (device.getProductId() == pid) {
 						usbDevice = device;
 						logger.info("USB XBee Android device found: " + usbDevice.getDeviceName());

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInterface.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInterface.java
@@ -414,14 +414,18 @@ public class AndroidUSBInterface implements IConnectionInterface {
 		UsbDevice usbDevice = null;
 		HashMap<String, UsbDevice> deviceList = usbManager.getDeviceList();
 		for (UsbDevice device:deviceList.values()) {
-			if (device.getVendorId() == VID[0] || device.getVendorId() == VID[1]) {
+			if (device.getVendorId() == VID[0]) {
 				for (int pid:UART_PIDS) {
 					if (device.getProductId() == pid) {
 						usbDevice = device;
-						logger.info("USB XBee Android device found: " + usbDevice.getDeviceName());
+						logger.info("USB XBee Android device from FTDI vendor found: " + usbDevice.getDeviceName());
 						break;
 					}
 				}
+			} else if (device.getVendorId() == VID[1] && device.getProductId() == UART_PIDS[0]){
+			        usbDevice = device;
+			        logger.info("USB XBee Android device from EXAR vendor found: " + usbDevice.getDeviceName());
+				break;
 			}
 			if (usbDevice != null) {
 				break;


### PR DESCRIPTION
1. Transform the VID variable into an array.
2. Add the new Vendor ID to support the EXAR brand.
3. Replace the name of variable FTDI_PIDS with UART_PIDS.
4. Add the new PID of the XR21V1410 for newly added Vendor ID.
5. Add a new condition to find devices (FTDI or EXAR).

Reference Document: 
[May24th.docx](https://github.com/BeechatNetworkSystemsLtd/BeechatNetwork-Android/files/8770427/May24th.docx)
 